### PR TITLE
Use own kms keys for EBS

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,15 @@ go test -v -timeout 30m
 
 ### Calico
 
-- https://docs.projectcalico.org/getting-started/kubernetes/managed-public-cloud/eks
-- https://docs.projectcalico.org/reference/public-cloud/aws#routing-traffic-within-a-single-vpc-subnet
-- https://docs.aws.amazon.com/vpc/latest/userguide/VPC_NAT_Instance.html#EIP_Disable_SrcDestCheck
-- https://github.com/awsdocs/amazon-eks-user-guide/blob/master/doc_source/calico.md
-- https://github.com/awsdocs/amazon-eks-user-guide/blob/master/doc_source/cni-custom-network.md
-- https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt
-- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI
+- <https://docs.projectcalico.org/getting-started/kubernetes/managed-public-cloud/eks>
+- <https://docs.projectcalico.org/reference/public-cloud/aws#routing-traffic-within-a-single-vpc-subnet>
+- <https://docs.aws.amazon.com/vpc/latest/userguide/VPC_NAT_Instance.html#EIP_Disable_SrcDestCheck>
+- <https://github.com/awsdocs/amazon-eks-user-guide/blob/master/doc_source/calico.md>
+- <https://github.com/awsdocs/amazon-eks-user-guide/blob/master/doc_source/cni-custom-network.md>
+- <https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt>
+- <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI>
 
 Launch templates are needed for Calico:
 
-- https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html
-- https://aws.amazon.com/blogs/containers/introducing-launch-template-and-custom-ami-support-in-amazon-eks-managed-node-groups/
+- <https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html>
+- <https://aws.amazon.com/blogs/containers/introducing-launch-template-and-custom-ami-support-in-amazon-eks-managed-node-groups/>

--- a/examples/basic/cluster.tf
+++ b/examples/basic/cluster.tf
@@ -5,7 +5,6 @@ module "cluster" {
   cluster_name    = "simple-eks-integration-test-for-eks-node-group"
   cluster_version = "1.20"
   vpc_name        = var.vpc_name
-  log_group_name  = "a-test-log-group-name"
 
   region  = var.aws_region
   profile = var.aws_profile

--- a/kms-key.tf
+++ b/kms-key.tf
@@ -1,0 +1,71 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_kms_key" "ebs_encryption_key" {
+  description             = "Encryption Key for EBS volumes"
+  deletion_window_in_days = 7
+
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    "Id": "auto-ebs-2",
+    "Statement": [
+        {
+            "Sid": "Allow access through EBS for all principals in the account that are authorized to use EBS",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Action": [
+                "kms:Encrypt",
+                "kms:Decrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:CreateGrant",
+                "kms:DescribeKey"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "kms:CallerAccount": data.aws_caller_identity.current.account_id,
+                    "kms:ViaService": "ec2.eu-west-1.amazonaws.com"
+                }
+            }
+        },
+        {
+                  "Sid": "Allow administration of the key",
+                  "Effect": "Allow",
+                  "Principal": {
+                    "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+                  },
+                  "Action": [
+                      "kms:Create*",
+                      "kms:Describe*",
+                      "kms:Enable*",
+                      "kms:List*",
+                      "kms:Put*",
+                      "kms:Update*",
+                      "kms:Revoke*",
+                      "kms:Disable*",
+                      "kms:Get*",
+                      "kms:Delete*",
+                      "kms:ScheduleKeyDeletion",
+                      "kms:CancelKeyDeletion"
+                  ],
+                  "Resource": "*"
+              },
+        {
+            "Sid": "Allow direct access to key metadata to the account",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+            },
+            "Action": [
+                "kms:Describe*",
+                "kms:Get*",
+                "kms:List*",
+                "kms:RevokeGrant"
+            ],
+            "Resource": "*"
+        }
+    ]
+  })
+}

--- a/launch-template.tf
+++ b/launch-template.tf
@@ -21,7 +21,7 @@ resource "aws_launch_template" "worker_nodes" {
 
     ebs {
       volume_size           = 20
-      volume_type           = "gp3"
+      volume_type           = "gp2"
       delete_on_termination = true
       encrypted             = var.encrypt_ebs
       kms_key_id            = var.encrypt_ebs ? aws_kms_key.ebs_encryption_key.arn: null

--- a/launch-template.tf
+++ b/launch-template.tf
@@ -21,9 +21,10 @@ resource "aws_launch_template" "worker_nodes" {
 
     ebs {
       volume_size           = 20
-      volume_type           = "gp2"
+      volume_type           = "gp3"
       delete_on_termination = true
       encrypted             = var.encrypt_ebs
+      kms_key_id            = var.encrypt_ebs ? aws_kms_key.ebs_encryption_key.arn: null
     }
   }
 


### PR DESCRIPTION
Use own KMS key for EBS encryption
Migrate volume type to gp3: https://aws.amazon.com/blogs/storage/migrate-your-amazon-ebs-volumes-from-gp2-to-gp3-and-save-up-to-20-on-costs/